### PR TITLE
Add more meta data to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.0.1"
 authors = ["Florian Gilcher <florian.gilcher@asquera.de>"]
 license = "MIT"
 description = "`escapade` provides String concatenation and writing, but automatically escapes any HTML in the data in the process. This prevents accidental unescaped writes to the output."
+keywords = ["html", "escaping", "strings"]
+repository = "https://github.com/skade/escapade"
+documentation = "https://docs.rs/escapade"
+readme = "README.md"


### PR DESCRIPTION
Don't you just hate it when you see a crate on crates.io that doesn't have a link to the repo or docs? :)

(I also added a few keywords; feel free to change them.)